### PR TITLE
add default styling to type=password

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -180,6 +180,7 @@ label {
 input[type=email],
 input[type=text],
 input[type=number],
+input[type=password],
 input:not([type]) {
   padding: 0.5rem;
   font-size: 1rem;
@@ -196,6 +197,7 @@ input:not([type]) {
   input[type=email],
   input[type=text],
   input[type=number],
+  input[type=password],
   input:not([type]) {
     background-color: #595859;
     border-color: #595859;


### PR DESCRIPTION
Default styling for input[type=password] is missing, suggest to style it as text/email